### PR TITLE
Add additional architectures for CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ rust:
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
+
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+
 jobs:
   allow_failures:
     fast_finish: true


### PR DESCRIPTION
Adds aarch64 and ppc64le to the CI config, since they have a weak memory ordering and thus could have different behavior with atomic orderings.